### PR TITLE
jni: Add support for cortex-a15 and x86 systems

### DIFF
--- a/app/src/main/java/com/opendoorstudios/ds4droid/About.java
+++ b/app/src/main/java/com/opendoorstudios/ds4droid/About.java
@@ -31,6 +31,8 @@ public class About extends Activity {
 		case DeSmuME.CPUTYPE_COMPAT: library = "compat"; break;
 		case DeSmuME.CPUTYPE_V7: library = "v7"; break;
 		case DeSmuME.CPUTYPE_NEON: library = "neon"; break;
+		case DeSmuME.CPUTYPE_A15: library = "a15"; break;
+		case DeSmuME.CPUTYPE_X86: library = "x86"; break;
 		default: library = "unknown";
 		}
 		

--- a/app/src/main/java/com/opendoorstudios/ds4droid/DeSmuME.java
+++ b/app/src/main/java/com/opendoorstudios/ds4droid/DeSmuME.java
@@ -32,6 +32,8 @@ class DeSmuME {
 	static final int CPUTYPE_COMPAT =  0;
 	static final int CPUTYPE_V7 = 1;
 	static final int CPUTYPE_NEON = 2;
+	static final int CPUTYPE_A15 = 3;
+	static final int CPUTYPE_X86 = 4;
 	
 	static void load()
 	{
@@ -40,6 +42,10 @@ class DeSmuME {
 		System.loadLibrary("cpudetect");
 		final int cpuType = getCPUType();
 		switch(cpuType) {
+		case CPUTYPE_A15:
+			System.loadLibrary("desmumea15");
+			Log.i(MainActivity.TAG, "Using cortex-a15 native library");
+			break;
 		case CPUTYPE_NEON:
 			System.loadLibrary("desmumeneon");
 			Log.i(MainActivity.TAG, "Using NEON enhanced native library");
@@ -47,6 +53,10 @@ class DeSmuME {
 		case CPUTYPE_V7:
 			System.loadLibrary("desmumev7");
 			Log.i(MainActivity.TAG, "Using ARMv7 native library");
+			break;
+		case CPUTYPE_X86:
+			System.loadLibrary("desmumex86");
+			Log.i(MainActivity.TAG, "Using x86 native library");
 			break;
 		default:
 			System.loadLibrary("desmumecompat");

--- a/app/src/main/jni/Android.mk
+++ b/app/src/main/jni/Android.mk
@@ -7,10 +7,14 @@ include $(CLEAR_VARS)
 include $(LOCAL_BUILD_PATH)/cpudetect/cpudetect.mk
 
 ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
+include $(LOCAL_BUILD_PATH)/desmume_a15.mk
 include $(LOCAL_BUILD_PATH)/desmume_neon.mk
 include $(LOCAL_BUILD_PATH)/desmume_v7.mk
 endif
 
+ifeq ($(TARGET_ARCH_ABI),x86)
+include $(LOCAL_BUILD_PATH)/desmume_x86.mk
+endif
+
 include $(LOCAL_BUILD_PATH)/desmume_compat.mk
 include $(LOCAL_BUILD_PATH)/desmume/src/android/7z/7z.mk
-

--- a/app/src/main/jni/cpudetect/cpu.cpp
+++ b/app/src/main/jni/cpudetect/cpu.cpp
@@ -23,6 +23,8 @@
 #define CPUTYPE_COMPAT 0
 #define CPUTYPE_V7 1
 #define CPUTYPE_NEON 2
+#define CPUTYPE_A15 3
+#define CPUTYPE_X86 4
 
 extern "C"
 {
@@ -31,15 +33,27 @@ jint JNI_NOARGS(getCPUType)
 {
 	AndroidCpuFamily cpuFamily = android_getCpuFamily();
 	uint64_t cpuFeatures = android_getCpuFeatures();
-	if (cpuFamily == ANDROID_CPU_FAMILY_ARM &&
-        (cpuFeatures & ANDROID_CPU_ARM_FEATURE_NEON) != 0)
-    {
-		return CPUTYPE_NEON;
-    }
-	else if (cpuFamily == ANDROID_CPU_FAMILY_ARM &&
-        (cpuFeatures & ANDROID_CPU_ARM_FEATURE_ARMv7) != 0)
+	if (cpuFamily == ANDROID_CPU_FAMILY_ARM)
 	{
-		return CPUTYPE_V7;
+		if ((cpuFeatures & ANDROID_CPU_ARM_FEATURE_IDIV_ARM) != 0)
+		{
+			return CPUTYPE_A15; // Should only bounce back to cortex-a15
+		}
+		else if ((cpuFeatures & ANDROID_CPU_ARM_FEATURE_NEON) != 0)
+		{
+			return CPUTYPE_NEON;
+		}
+		else if ((cpuFeatures & ANDROID_CPU_ARM_FEATURE_ARMv7) != 0)
+		{
+			return CPUTYPE_V7;
+		}
+	}
+	else if (cpuFamily == ANDROID_CPU_FAMILY_X86)
+	{
+		if ((cpuFeatures & ANDROID_CPU_X86_FEATURE_SSSE3) != 0)
+		{
+			return CPUTYPE_X86; // Check can be removed if ALL x86 feature SSE3
+		}
 	}
     else
     {

--- a/app/src/main/jni/cpudetect/cpu.cpp
+++ b/app/src/main/jni/cpudetect/cpu.cpp
@@ -50,10 +50,7 @@ jint JNI_NOARGS(getCPUType)
 	}
 	else if (cpuFamily == ANDROID_CPU_FAMILY_X86)
 	{
-		if ((cpuFeatures & ANDROID_CPU_X86_FEATURE_SSSE3) != 0)
-		{
-			return CPUTYPE_X86; // Check can be removed if ALL x86 feature SSE3
-		}
+		return CPUTYPE_X86;
 	}
     else
     {

--- a/app/src/main/jni/desmume_a15.mk
+++ b/app/src/main/jni/desmume_a15.mk
@@ -1,0 +1,133 @@
+# Android ndk makefile for ds4droid
+
+LOCAL_PATH := $(call my-dir)
+
+MY_LOCAL_PATH := $(LOCAL_PATH)
+
+include $(CLEAR_VARS)
+
+
+LOCAL_MODULE    		:= 	libdesmumea15
+LOCAL_C_INCLUDES		:= 	$(LOCAL_PATH)/desmume/src \
+							$(LOCAL_PATH)/desmume/src/android \
+							$(LOCAL_PATH)/desmume/src/android/7z/CPP \
+							$(LOCAL_PATH)/desmume/src/android/7z/CPP/include_windows \
+							$(LOCAL_PATH)/desmume/src/android/7z/CPP/myWindows \
+							$(LOCAL_PATH)/desmume/src/utils/lightning/include
+						   
+LOCAL_SRC_FILES			:= 	desmume/src/addons/slot1_none.cpp \
+							desmume/src/addons/slot1_r4.cpp \
+							desmume/src/addons/slot1_retail.cpp \
+							desmume/src/addons/slot1_retail_nand.cpp \
+							desmume/src/addons/slot2_expMemory.cpp \
+							desmume/src/addons/slot2_gbagame.cpp \
+							desmume/src/addons/slot2_guitarGrip.cpp \
+							desmume/src/addons/slot2_mpcf.cpp \
+							desmume/src/addons/slot2_none.cpp \
+							desmume/src/addons/slot2_paddle.cpp \
+							desmume/src/addons/slot2_piano.cpp \
+							desmume/src/addons/slot2_rumblepak.cpp \
+							desmume/src/utils/decrypt/crc.cpp \
+							desmume/src/utils/decrypt/decrypt.cpp \
+							desmume/src/utils/decrypt/header.cpp \
+							desmume/src/utils/libfat/cache.cpp \
+							desmume/src/utils/libfat/directory.cpp \
+							desmume/src/utils/libfat/disc.cpp \
+							desmume/src/utils/libfat/fatfile.cpp \
+							desmume/src/utils/libfat/fatdir.cpp \
+							desmume/src/utils/libfat/file_allocation_table.cpp \
+							desmume/src/utils/libfat/filetime.cpp \
+							desmume/src/utils/libfat/libfat.cpp \
+							desmume/src/utils/libfat/libfat_public_api.cpp \
+							desmume/src/utils/libfat/lock.cpp \
+							desmume/src/utils/libfat/partition.cpp \
+							desmume/src/utils/tinyxml/tinyxml.cpp \
+							desmume/src/utils/tinyxml/tinyxmlparser.cpp \
+							desmume/src/utils/tinyxml/tinyxmlerror.cpp \
+							desmume/src/utils/tinyxml/tinystr.cpp \
+							desmume/src/utils/ConvertUTF.c \
+							desmume/src/utils/datetime.cpp \
+							desmume/src/utils/dlditool.cpp \
+							desmume/src/utils/emufat.cpp \
+							desmume/src/utils/FileMap.cpp \
+							desmume/src/utils/guid.cpp \
+							desmume/src/utils/md5.cpp \
+							desmume/src/utils/MemBuffer.cpp \
+							desmume/src/utils/task.cpp \
+							desmume/src/utils/vfat.cpp \
+							desmume/src/utils/xstring.cpp \
+							desmume/src/metaspu/metaspu.cpp \
+							desmume/src/filter/2xsai.cpp \
+							desmume/src/filter/bilinear.cpp \
+							desmume/src/filter/epx.cpp \
+							desmume/src/filter/hq2x.cpp \
+							desmume/src/filter/hq4x.cpp \
+							desmume/src/filter/lq2x.cpp \
+							desmume/src/filter/scanline.cpp \
+							desmume/src/addons.cpp \
+							desmume/src/arm_instructions.cpp \
+							desmume/src/ArmAnalyze.cpp \
+							desmume/src/armcpu.cpp \
+							desmume/src/ArmThreadedInterpreter.cpp \
+							desmume/src/ArmLJit.cpp \
+							desmume/src/bios.cpp \
+							desmume/src/cheatSystem.cpp \
+							desmume/src/common.cpp \
+							desmume/src/cp15.cpp \
+							desmume/src/CpuBase.cpp \
+							desmume/src/debug.cpp \
+							desmume/src/Disassembler.cpp \
+							desmume/src/driver.cpp \
+							desmume/src/emufile.cpp \
+							desmume/src/FIFO.cpp \
+							desmume/src/firmware.cpp \
+							desmume/src/fs-linux.cpp \
+							desmume/src/gfx3d.cpp \
+							desmume/src/GPU.cpp \
+							desmume/src/GPU_osd_stub.cpp \
+							desmume/src/JitCommon.cpp \
+							desmume/src/matrix.cpp \
+							desmume/src/mc.cpp \
+							desmume/src/MMU.cpp \
+							desmume/src/movie.cpp \
+							desmume/src/NDSSystem.cpp \
+							desmume/src/OGLES2Render.cpp \
+							desmume/src/path.cpp \
+							desmume/src/rasterize.cpp \
+							desmume/src/readwrite.cpp \
+							desmume/src/render3D.cpp \
+							desmume/src/ROMReader.cpp \
+							desmume/src/rtc.cpp \
+							desmume/src/saves.cpp \
+							desmume/src/slot1.cpp \
+							desmume/src/SPU.cpp \
+							desmume/src/texcache.cpp \
+							desmume/src/thumb_instructions.cpp \
+							desmume/src/version.cpp \
+							desmume/src/wifi.cpp \
+							desmume/src/android/mic.cpp \
+							desmume/src/android/throttle.cpp \
+							desmume/src/android/main.cpp \
+							desmume/src/android/OpenArchive.cpp \
+							desmume/src/android/7zip.cpp \
+							desmume/src/android/neontest.cpp \
+							desmume/src/android/sndopensl.cpp \
+							desmume/src/android/draw.cpp 
+							
+LOCAL_ARM_NEON 			:= true
+LOCAL_ARM_MODE 			:= arm
+LOCAL_CFLAGS			:= -DANDROID -DHAVE_LIBZ -DNO_MEMDEBUG -DNO_GPUDEBUG -DHAVE_JIT -DLIGHTNING_ARM -DHAVE_NEON=1 -mfloat-abi=softfp -mfpu=neon-vfpv4 -marm -march=armv7-a -mtune=cortex-a15
+LOCAL_STATIC_LIBRARIES 	:= mathneon sevenzip
+LOCAL_LDLIBS 			:= -llog -lz -lEGL -lGLESv2 -ljnigraphics -lOpenSLES -landroid
+
+#For profiling
+#LOCAL_CFLAGS += -DUSE_PROFILER -pg
+#LOCAL_STATIC_LIBRARIES += android-ndk-profiler
+
+#To check for speed improvements
+#LOCAL_CFLAGS += -DMEASURE_FIRST_FRAMES
+
+include $(BUILD_SHARED_LIBRARY)
+
+#include $(MY_LOCAL_PATH)/android-ndk-profiler/Android.mk
+include $(MY_LOCAL_PATH)/desmume/src/android/math-neon/Android.mk

--- a/app/src/main/jni/desmume_compat.mk
+++ b/app/src/main/jni/desmume_compat.mk
@@ -12,6 +12,7 @@ LOCAL_C_INCLUDES		:= 	$(LOCAL_PATH)/desmume/src \
 							$(LOCAL_PATH)/desmume/src/android \
 							$(LOCAL_PATH)/desmume/src/android/7z/CPP \
 							$(LOCAL_PATH)/desmume/src/android/7z/CPP/include_windows \
+							$(LOCAL_PATH)/desmume/src/android/7z/CPP/myWindows \
 							$(LOCAL_PATH)/desmume/src/utils/lightning/include
 						   
 LOCAL_SRC_FILES			:= 	desmume/src/addons/slot1_none.cpp \
@@ -130,5 +131,14 @@ ifeq ($(TARGET_ARCH_ABI),x86)
 LOCAL_CFLAGS			+= -DLIGHTNING_I386
 endif
 
+#For profiling
+#LOCAL_CFLAGS += -DUSE_PROFILER -pg
+#LOCAL_STATIC_LIBRARIES += android-ndk-profiler
+
+#To check for speed improvements
+#LOCAL_CFLAGS += -DMEASURE_FIRST_FRAMES
+
 include $(BUILD_SHARED_LIBRARY)
 
+#include $(MY_LOCAL_PATH)/android-ndk-profiler/Android.mk
+#include $(MY_LOCAL_PATH)/desmume/src/android/math-neon/Android.mk

--- a/app/src/main/jni/desmume_neon.mk
+++ b/app/src/main/jni/desmume_neon.mk
@@ -129,6 +129,5 @@ LOCAL_LDLIBS 			:= -llog -lz -lEGL -lGLESv2 -ljnigraphics -lOpenSLES -landroid
 
 include $(BUILD_SHARED_LIBRARY)
 
-include $(MY_LOCAL_PATH)/android-ndk-profiler/Android.mk
+#include $(MY_LOCAL_PATH)/android-ndk-profiler/Android.mk
 include $(MY_LOCAL_PATH)/desmume/src/android/math-neon/Android.mk
-

--- a/app/src/main/jni/desmume_v7.mk
+++ b/app/src/main/jni/desmume_v7.mk
@@ -12,6 +12,7 @@ LOCAL_C_INCLUDES		:= 	$(LOCAL_PATH)/desmume/src \
 							$(LOCAL_PATH)/desmume/src/android \
 							$(LOCAL_PATH)/desmume/src/android/7z/CPP \
 							$(LOCAL_PATH)/desmume/src/android/7z/CPP/include_windows \
+							$(LOCAL_PATH)/desmume/src/android/7z/CPP/myWindows \
 							$(LOCAL_PATH)/desmume/src/utils/lightning/include
 						   
 LOCAL_SRC_FILES			:= 	desmume/src/addons/slot1_none.cpp \
@@ -118,9 +119,14 @@ LOCAL_CFLAGS			:= -DANDROID -DHAVE_LIBZ -DNO_MEMDEBUG -DNO_GPUDEBUG -DHAVE_JIT -
 LOCAL_STATIC_LIBRARIES 	:= sevenzip tinyccarm
 LOCAL_LDLIBS 			:= -llog -lz -lGLESv2 -lEGL -ljnigraphics -lOpenSLES -landroid 
 
+#For profiling
+#LOCAL_CFLAGS += -DUSE_PROFILER -pg
+#LOCAL_STATIC_LIBRARIES += android-ndk-profiler
+
 #To check for speed improvements
 #LOCAL_CFLAGS += -DMEASURE_FIRST_FRAMES
 
 include $(BUILD_SHARED_LIBRARY)
 
-
+#include $(MY_LOCAL_PATH)/android-ndk-profiler/Android.mk
+#include $(MY_LOCAL_PATH)/desmume/src/android/math-neon/Android.mk

--- a/app/src/main/jni/desmume_x86.mk
+++ b/app/src/main/jni/desmume_x86.mk
@@ -1,0 +1,132 @@
+# Android ndk makefile for ds4droid
+
+LOCAL_PATH := $(call my-dir)
+
+MY_LOCAL_PATH := $(LOCAL_PATH)
+
+include $(CLEAR_VARS)
+
+
+LOCAL_MODULE    		:= 	libdesmumex86
+LOCAL_C_INCLUDES		:= 	$(LOCAL_PATH)/desmume/src \
+							$(LOCAL_PATH)/desmume/src/android \
+							$(LOCAL_PATH)/desmume/src/android/7z/CPP \
+							$(LOCAL_PATH)/desmume/src/android/7z/CPP/include_windows \
+							$(LOCAL_PATH)/desmume/src/android/7z/CPP/myWindows \
+							$(LOCAL_PATH)/desmume/src/utils/lightning/include
+						   
+LOCAL_SRC_FILES			:= 	desmume/src/addons/slot1_none.cpp \
+							desmume/src/addons/slot1_r4.cpp \
+							desmume/src/addons/slot1_retail.cpp \
+							desmume/src/addons/slot1_retail_nand.cpp \
+							desmume/src/addons/slot2_expMemory.cpp \
+							desmume/src/addons/slot2_gbagame.cpp \
+							desmume/src/addons/slot2_guitarGrip.cpp \
+							desmume/src/addons/slot2_mpcf.cpp \
+							desmume/src/addons/slot2_none.cpp \
+							desmume/src/addons/slot2_paddle.cpp \
+							desmume/src/addons/slot2_piano.cpp \
+							desmume/src/addons/slot2_rumblepak.cpp \
+							desmume/src/utils/decrypt/crc.cpp \
+							desmume/src/utils/decrypt/decrypt.cpp \
+							desmume/src/utils/decrypt/header.cpp \
+							desmume/src/utils/libfat/cache.cpp \
+							desmume/src/utils/libfat/directory.cpp \
+							desmume/src/utils/libfat/disc.cpp \
+							desmume/src/utils/libfat/fatfile.cpp \
+							desmume/src/utils/libfat/fatdir.cpp \
+							desmume/src/utils/libfat/file_allocation_table.cpp \
+							desmume/src/utils/libfat/filetime.cpp \
+							desmume/src/utils/libfat/libfat.cpp \
+							desmume/src/utils/libfat/libfat_public_api.cpp \
+							desmume/src/utils/libfat/lock.cpp \
+							desmume/src/utils/libfat/partition.cpp \
+							desmume/src/utils/tinyxml/tinyxml.cpp \
+							desmume/src/utils/tinyxml/tinyxmlparser.cpp \
+							desmume/src/utils/tinyxml/tinyxmlerror.cpp \
+							desmume/src/utils/tinyxml/tinystr.cpp \
+							desmume/src/utils/ConvertUTF.c \
+							desmume/src/utils/datetime.cpp \
+							desmume/src/utils/dlditool.cpp \
+							desmume/src/utils/emufat.cpp \
+							desmume/src/utils/FileMap.cpp \
+							desmume/src/utils/guid.cpp \
+							desmume/src/utils/md5.cpp \
+							desmume/src/utils/MemBuffer.cpp \
+							desmume/src/utils/task.cpp \
+							desmume/src/utils/vfat.cpp \
+							desmume/src/utils/xstring.cpp \
+							desmume/src/metaspu/metaspu.cpp \
+							desmume/src/filter/2xsai.cpp \
+							desmume/src/filter/bilinear.cpp \
+							desmume/src/filter/epx.cpp \
+							desmume/src/filter/hq2x.cpp \
+							desmume/src/filter/hq4x.cpp \
+							desmume/src/filter/lq2x.cpp \
+							desmume/src/filter/scanline.cpp \
+							desmume/src/addons.cpp \
+							desmume/src/arm_instructions.cpp \
+							desmume/src/ArmAnalyze.cpp \
+							desmume/src/armcpu.cpp \
+							desmume/src/ArmThreadedInterpreter.cpp \
+							desmume/src/ArmLJit.cpp \
+							desmume/src/bios.cpp \
+							desmume/src/cheatSystem.cpp \
+							desmume/src/common.cpp \
+							desmume/src/cp15.cpp \
+							desmume/src/CpuBase.cpp \
+							desmume/src/debug.cpp \
+							desmume/src/Disassembler.cpp \
+							desmume/src/driver.cpp \
+							desmume/src/emufile.cpp \
+							desmume/src/FIFO.cpp \
+							desmume/src/firmware.cpp \
+							desmume/src/fs-linux.cpp \
+							desmume/src/gfx3d.cpp \
+							desmume/src/GPU.cpp \
+							desmume/src/GPU_osd_stub.cpp \
+							desmume/src/JitCommon.cpp \
+							desmume/src/matrix.cpp \
+							desmume/src/mc.cpp \
+							desmume/src/MMU.cpp \
+							desmume/src/movie.cpp \
+							desmume/src/NDSSystem.cpp \
+							desmume/src/OGLES2Render.cpp \
+							desmume/src/path.cpp \
+							desmume/src/rasterize.cpp \
+							desmume/src/readwrite.cpp \
+							desmume/src/render3D.cpp \
+							desmume/src/ROMReader.cpp \
+							desmume/src/rtc.cpp \
+							desmume/src/saves.cpp \
+							desmume/src/slot1.cpp \
+							desmume/src/SPU.cpp \
+							desmume/src/texcache.cpp \
+							desmume/src/thumb_instructions.cpp \
+							desmume/src/version.cpp \
+							desmume/src/wifi.cpp \
+							desmume/src/android/mic.cpp \
+							desmume/src/android/throttle.cpp \
+							desmume/src/android/main.cpp \
+							desmume/src/android/OpenArchive.cpp \
+							desmume/src/android/7zip.cpp \
+							desmume/src/android/sndopensl.cpp \
+							desmume/src/android/draw.cpp 
+							
+LOCAL_ARM_NEON 			:= false
+LOCAL_ARM_MODE 			:= thumb
+LOCAL_CFLAGS			:= -DANDROID -DHAVE_LIBZ -DNO_MEMDEBUG -DNO_GPUDEBUG -DHAVE_JIT -DLIGHTNING_I386 -march=i686 -mtune=intel -mssse3 -mfpmath=sse -m32
+LOCAL_STATIC_LIBRARIES 	:= sevenzip
+LOCAL_LDLIBS 			:= -llog -lz -lEGL -lGLESv2 -ljnigraphics -lOpenSLES -landroid
+
+#For profiling
+#LOCAL_CFLAGS += -DUSE_PROFILER -pg
+#LOCAL_STATIC_LIBRARIES += android-ndk-profiler
+
+#To check for speed improvements
+#LOCAL_CFLAGS += -DMEASURE_FIRST_FRAMES
+
+include $(BUILD_SHARED_LIBRARY)
+
+#include $(MY_LOCAL_PATH)/android-ndk-profiler/Android.mk
+#include $(MY_LOCAL_PATH)/desmume/src/android/math-neon/Android.mk


### PR DESCRIPTION
Temporarily abandoned - x86 is separate from Lightning JIT as it was developed for ARM, so it may require some reworking.

I'm considering reworking this PR to make the build system cleaner, although improving flags for performance is still a goal.